### PR TITLE
LAMBDA-178: execute getThumbnail every upload site load

### DIFF
--- a/portal/forms.py
+++ b/portal/forms.py
@@ -25,7 +25,7 @@ def getThumbnails(thumbssettings):
 
 class MediaItemForm(ModelForm):
     ''' Used for the uploading form '''
-    thumbURL = forms.ChoiceField(choices=getThumbnails(settings.THUMBNAILS_DIR), required=False, label=_("Thumbnail"))
+    thumbURL = forms.ChoiceField(required=False, label=_("Thumbnail"))
     fileFormats = forms.MultipleChoiceField(choices=FILE_FORMATS, required=True, label=_("File Formats"))
 
     class Meta:
@@ -35,6 +35,7 @@ class MediaItemForm(ModelForm):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('label_suffix', '')
         super(MediaItemForm, self).__init__(*args, **kwargs)
+        self.fields['thumbURL'].choices = getThumbnails(settings.THUMBNAILS_DIR)
         for fieldName in self.fields:
             field = self.fields[fieldName]
             field.widget.attrs['class'] = 'form-control'


### PR DESCRIPTION
This can be done better now with django >= 1.8, so this should be changed over to using a callable for `choises` (https://docs.djangoproject.com/en/1.8/ref/forms/fields/#django.forms.ChoiceField.choices). But still opening a PR so it's better visible than just the branch.

fixes #171